### PR TITLE
Loosen pact-support version requirement

### DIFF
--- a/pact_expectations.gemspec
+++ b/pact_expectations.gemspec
@@ -17,9 +17,9 @@ Gem::Specification.new do |spec|
   spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "pact-support", "~> 0.5.4"
+  spec.add_dependency "pact-support", ">= 0.5.4"
 
-  spec.add_development_dependency "pact", "~> 1.9"
+  spec.add_development_dependency "pact", ">= 1.9"
   spec.add_development_dependency "bundler", "~> 1.11"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"


### PR DESCRIPTION
It seems no reason to pin version.