### PR TITLE
Rack2.0 no longer supports ruby under 2.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: ruby
 rvm:
-  - 2.1.8
   - 2.2.4
   - 2.3.0
 before_install: gem install bundler -v 1.11.2


### PR DESCRIPTION
Instead of maintaining multiple gem dependencies, just drop support of ruby under 2.2. How about this?